### PR TITLE
Publicize Item Scripts

### DIFF
--- a/UsualScrap/Behaviors/BandagesScript.cs
+++ b/UsualScrap/Behaviors/BandagesScript.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace UsualScrap.Behaviors
 {
-    internal class BandagesScript : GrabbableObject
+    public class BandagesScript : GrabbableObject
     {
         public NetworkVariable<int> savedUses = new NetworkVariable<int>(3, NetworkVariableReadPermission.Everyone, NetworkVariableWritePermission.Server);
         int uses = 3;
@@ -92,3 +92,4 @@ namespace UsualScrap.Behaviors
 
     }
 }
+

--- a/UsualScrap/Behaviors/BloodyCapsuleScript.cs
+++ b/UsualScrap/Behaviors/BloodyCapsuleScript.cs
@@ -6,7 +6,7 @@ using UnityEngine.AI;
 
 namespace UsualScrap.Behaviors
 {
-    internal class BloodyCapsuleScript : GrabbableObject
+    public class BloodyCapsuleScript : GrabbableObject
     {
         ParticleSystem chargedParticles;
         ParticleSystem chargingParticles;
@@ -182,3 +182,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/CandyDispenserScript.cs
+++ b/UsualScrap/Behaviors/CandyDispenserScript.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace UsualScrap.Behaviors
 {
-    internal class CandyDispenserScript : GrabbableObject
+    public class CandyDispenserScript : GrabbableObject
     {
         RaycastHit[] objectsHitByMeleeWeapon;
         List<RaycastHit> objectsHitByMeleeWeaponList = new List<RaycastHit>();
@@ -285,4 +285,5 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+
 

--- a/UsualScrap/Behaviors/CandyScript.cs
+++ b/UsualScrap/Behaviors/CandyScript.cs
@@ -3,7 +3,7 @@ using UsualScrap.Behaviors.Effects;
 
 namespace UsualScrap.Behaviors
 {
-    internal class CandyScript : GrabbableObject
+    public class CandyScript : GrabbableObject
     {
         public override void ItemActivate(bool used, bool buttonDown = true)
         {
@@ -26,3 +26,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/CaneScript.cs
+++ b/UsualScrap/Behaviors/CaneScript.cs
@@ -1,6 +1,6 @@
 ﻿namespace UsualScrap.Behaviors
 {
-    internal class CaneScript : GrabbableObject
+    public class CaneScript : GrabbableObject
     {
         float movementbuff = 1f;
 
@@ -21,3 +21,4 @@
         }
     }
 }
+

--- a/UsualScrap/Behaviors/CrowbarScript.cs
+++ b/UsualScrap/Behaviors/CrowbarScript.cs
@@ -8,7 +8,7 @@ using UnityEngine;
 
 namespace UsualScrap.Behaviors
 {
-    internal class CrowbarScript : GrabbableObject
+    public class CrowbarScript : GrabbableObject
     {
         PlayerControllerB previousPlayerHeldBy;
         DoorLock viewedDoorLock;
@@ -249,4 +249,5 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+
 

--- a/UsualScrap/Behaviors/DefibrillatorScript.cs
+++ b/UsualScrap/Behaviors/DefibrillatorScript.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace UsualScrap.Behaviors
 {
-    internal class DefibrillatorScript : GrabbableObject
+    public class DefibrillatorScript : GrabbableObject
     {
         Coroutine coroutine;
         bool ReadyingDefib = false;
@@ -447,3 +447,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/DefibrillatorScript.cs
+++ b/UsualScrap/Behaviors/DefibrillatorScript.cs
@@ -404,12 +404,10 @@ namespace UsualScrap.Behaviors
                         PlayerScript.currentVoiceChatIngameSettings.InitializeComponents();
                     }
 
-                    if (PlayerScript.currentVoiceChatIngameSettings.voiceAudio == null)
+                    if (PlayerScript.currentVoiceChatIngameSettings.voiceAudio != null)
                     {
-                        return;
+                        PlayerScript.currentVoiceChatIngameSettings.voiceAudio.GetComponent<OccludeAudio>().overridingLowPass = false;
                     }
-
-                    PlayerScript.currentVoiceChatIngameSettings.voiceAudio.GetComponent<OccludeAudio>().overridingLowPass = false;
                 }
             }
             PlayerControllerB localplayercontroller = GameNetworkManager.Instance.localPlayerController;
@@ -447,4 +445,5 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+
 

--- a/UsualScrap/Behaviors/DoomsayerBellScript.cs
+++ b/UsualScrap/Behaviors/DoomsayerBellScript.cs
@@ -2,7 +2,7 @@
 
 namespace UsualScrap.Behaviors
 {
-    internal class DoomsayerBellScript : GrabbableObject
+    public class DoomsayerBellScript : GrabbableObject
     {
         AudioSource[] audioSource;
         AudioClip clip;
@@ -41,3 +41,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/EmergencyInjectorScript.cs
+++ b/UsualScrap/Behaviors/EmergencyInjectorScript.cs
@@ -4,7 +4,7 @@ using Unity.Netcode;
 
 namespace UsualScrap.Behaviors
 {
-    internal class EmergencyInjectorScript : GrabbableObject
+    public class EmergencyInjectorScript : GrabbableObject
     {
         AudioSource audioSource;
         GameObject InjectorContents;
@@ -46,3 +46,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/FrigidCapsuleScript.cs
+++ b/UsualScrap/Behaviors/FrigidCapsuleScript.cs
@@ -7,7 +7,7 @@ using UsualScrap.Behaviors.Effects;
 
 namespace UsualScrap.Behaviors
 {
-    internal class FrigidCapsuleScript : GrabbableObject
+    public class FrigidCapsuleScript : GrabbableObject
     {
         ParticleSystem chargingSnowflakeParticles;
         ParticleSystem ambientSnowflakeParticles;
@@ -334,3 +334,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/GloomyCapsuleScript.cs
+++ b/UsualScrap/Behaviors/GloomyCapsuleScript.cs
@@ -7,7 +7,7 @@ using UnityEngine.Events;
 
 namespace UsualScrap.Behaviors
 {
-    internal class GloomyCapsuleScript : GrabbableObject
+    public class GloomyCapsuleScript : GrabbableObject
     {
         ParticleSystem teleportParticles;
         ParticleSystem createdTeleportParticles;
@@ -255,3 +255,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/GoldenTicketScript.cs
+++ b/UsualScrap/Behaviors/GoldenTicketScript.cs
@@ -6,7 +6,7 @@ using Object = UnityEngine.Object;
 
 namespace UsualScrap.Behaviors
 {
-    internal class GoldenTicketScript : GrabbableObject
+    public class GoldenTicketScript : GrabbableObject
     {
         ParticleSystem idleSparkle;
         bool particlePlaying = true;
@@ -189,3 +189,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/HandlampScript.cs
+++ b/UsualScrap/Behaviors/HandlampScript.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace UsualScrap.Behaviors
 {
-    internal class HandlampScript : GrabbableObject
+    public class HandlampScript : GrabbableObject
     {
         Light[] lights;
         Light light;
@@ -114,3 +114,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/MedicalKitScript.cs
+++ b/UsualScrap/Behaviors/MedicalKitScript.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace UsualScrap.Behaviors
 {
-    internal class MedicalKitScript : GrabbableObject
+    public class MedicalKitScript : GrabbableObject
     {
         int Healthpool = 150;
         private Coroutine healCoroutine;
@@ -217,3 +217,4 @@ namespace UsualScrap.Behaviors
     }
 
 }
+

--- a/UsualScrap/Behaviors/NoiseMakerItemScript.cs
+++ b/UsualScrap/Behaviors/NoiseMakerItemScript.cs
@@ -2,7 +2,7 @@
 
 namespace UsualScrap.Behaviors
 {
-    internal class NoiseMakerItemScript : GrabbableObject
+    public class NoiseMakerItemScript : GrabbableObject
     {
         AudioSource[] sources;
         AudioClip clip;
@@ -27,3 +27,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/NoxiousCapsuleScript.cs
+++ b/UsualScrap/Behaviors/NoxiousCapsuleScript.cs
@@ -8,7 +8,7 @@ using UsualScrap.Behaviors.Effects;
 
 namespace UsualScrap.Behaviors
 {
-    internal class NoxiousCapsuleScript : GrabbableObject
+    public class NoxiousCapsuleScript : GrabbableObject
     {
         ParticleSystem ambientSporeParticles;
         ParticleSystem noxiousCloudParticles;

--- a/UsualScrap/Behaviors/PadlockScript.cs
+++ b/UsualScrap/Behaviors/PadlockScript.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace UsualScrap.Behaviors
 {
-    internal class PadlockScript : GrabbableObject
+    public class PadlockScript : GrabbableObject
     {
         DoorLock viewedDoorLock;
         AudioSource lockSound;
@@ -69,3 +69,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/PieceofCandyScript.cs
+++ b/UsualScrap/Behaviors/PieceofCandyScript.cs
@@ -4,7 +4,7 @@ using UsualScrap.Behaviors.Effects;
 
 namespace UsualScrap.Behaviors
 {
-    internal class PieceofCandyScript : GrabbableObject
+    public class PieceofCandyScript : GrabbableObject
     {
         //int randomEffect = new System.Random().Next(1, 4);
         MeshRenderer candyMesh;
@@ -60,3 +60,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/ProductivityAutoinjectorScript.cs
+++ b/UsualScrap/Behaviors/ProductivityAutoinjectorScript.cs
@@ -4,7 +4,7 @@ using UsualScrap.Behaviors.Effects;
 
 namespace UsualScrap.Behaviors
 {
-    internal class ProductivityAutoinjectorScript : GrabbableObject
+    public class ProductivityAutoinjectorScript : GrabbableObject
     {
         AudioSource audioSource;
         MeshRenderer InjectorDisplay;
@@ -66,3 +66,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/RadioactiveCellScript.cs
+++ b/UsualScrap/Behaviors/RadioactiveCellScript.cs
@@ -3,7 +3,7 @@ using Unity.Netcode;
 
 namespace UsualScrap.Behaviors
 {
-    internal class RadioactiveCellScript : GrabbableObject
+    public class RadioactiveCellScript : GrabbableObject
     {
         Light light;
         ParticleSystem particle;
@@ -101,3 +101,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/RoseScript.cs
+++ b/UsualScrap/Behaviors/RoseScript.cs
@@ -2,7 +2,7 @@
 
 namespace UsualScrap.Behaviors
 {
-    internal class RoseScript : GrabbableObject
+    public class RoseScript : GrabbableObject
     {
         PlayerControllerB player;
         public override void EquipItem()
@@ -23,3 +23,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/SanguineCapsuleScript.cs
+++ b/UsualScrap/Behaviors/SanguineCapsuleScript.cs
@@ -7,7 +7,7 @@ using static UnityEngine.ParticleSystem;
 
 namespace UsualScrap.Behaviors
 {
-    internal class SanguineCapsuleScript : GrabbableObject
+    public class SanguineCapsuleScript : GrabbableObject
     {
         ParticleSystem chargedParticles;
         ParticleSystem chargingParticles;
@@ -99,3 +99,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/ScissorsScript.cs
+++ b/UsualScrap/Behaviors/ScissorsScript.cs
@@ -9,7 +9,7 @@ using Unity.Netcode;
 
 namespace UsualScrap.Behaviors
 {
-    internal class ScissorsScript : GrabbableObject
+    public class ScissorsScript : GrabbableObject
     {
         private Coroutine coroutine;
 
@@ -249,3 +249,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+

--- a/UsualScrap/Behaviors/ShiftControllerScript.cs
+++ b/UsualScrap/Behaviors/ShiftControllerScript.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 
 namespace UsualScrap.Behaviors
 {
-    internal class ShiftControllerScript : GrabbableObject
+    public class ShiftControllerScript : GrabbableObject
     {
         bool teleportSetIndoors;
         Vector3 savedLocation;

--- a/UsualScrap/Behaviors/TicketScript.cs
+++ b/UsualScrap/Behaviors/TicketScript.cs
@@ -6,7 +6,7 @@ using Object = UnityEngine.Object;
 
 namespace UsualScrap.Behaviors
 {
-    internal class TicketScript : GrabbableObject
+    public class TicketScript : GrabbableObject
     {
         public static Item _giftBoxItem;
         Object viewedGameObject;

--- a/UsualScrap/Behaviors/ToolboxScript.cs
+++ b/UsualScrap/Behaviors/ToolboxScript.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 
 namespace UsualScrap.Behaviors
 {
-    internal class ToolboxScript : GrabbableObject
+    public class ToolboxScript : GrabbableObject
     {
         private static Item _laserPointerItem;
         private static Item _bigBoltItem;
@@ -270,4 +270,5 @@ namespace UsualScrap.Behaviors
             return _bigBoltItem;
         }
     }
+
 }

--- a/UsualScrap/Behaviors/WalkingCaneScript.cs
+++ b/UsualScrap/Behaviors/WalkingCaneScript.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace UsualScrap.Behaviors
 {
-    internal class WalkingCaneScript : GrabbableObject
+    public class WalkingCaneScript : GrabbableObject
     {
         private PlayerControllerB Player;
         readonly float speedBuff = 1.5f;
@@ -36,3 +36,4 @@ namespace UsualScrap.Behaviors
         }
     }
 }
+


### PR DESCRIPTION
Hello, I'm the creator of the mod Lethal Bots and was working on adding support of your mod to mine, but I ran into an issue. Most of your item scripts are marked as internal. It makes it harder for me and other modders to make harmony patches. I mean, I could just reverse patch and use reflection, but I would prefer a much more official method if possible. The only changes I made was making the classes public and a minor logic error fix in the DefibrillatorScript. Other than that, no other logic was changed! 

Edit - I made the edits directly on GitHub, so I yeah, GitHub might have messed with the formatting.......